### PR TITLE
Don't supply unknown arguments to `full_join()`

### DIFF
--- a/R/overview_overlap.R
+++ b/R/overview_overlap.R
@@ -69,13 +69,7 @@ overview_overlap <-
       # Merge both data sets to get a better idea of the overlap
       subset <-
         # Join both data sets
-        dplyr::full_join(
-          x = dat1_final,
-          y = dat2_final,
-          by.x = !!dat1_id,
-          by.y = !!dat2_id,
-          all = TRUE
-        )
+        dplyr::full_join(x = dat1_final, y = dat2_final)
 
       # Plot it
       plot <- subset %>%


### PR DESCRIPTION
For compatibility with dplyr 1.1.0 where the join functions are now stricter with unknown arguments instead of ignoring them.

We plan to release dplyr on January 27. If possible, a pre-emptive fix release would be helpful to our release process. Thanks!